### PR TITLE
Made the link to repo clearer to understand and to be clicked on

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -71,3 +71,4 @@ body, html {
 #comment-textarea {
   background: transparent !important;
 }
+

--- a/views/searchResults.handlebars
+++ b/views/searchResults.handlebars
@@ -7,8 +7,7 @@
     <div class="card-body">
       <h1 id="repo-fullName">{{fullName}}</h1>
 
-      <a href="{{link}}" target="_blank" id="repo-link">{{link}}</a>
-
+      <p><b>Link to Repository: </b><a href="{{link}}" target="_blank" id="repo-link">{{link}}</a></p>
         <p>
         {{#if language}}
         <b>Language:</b> <b id="repo-language">{{language}}</b> | 

--- a/views/searchResults.handlebars
+++ b/views/searchResults.handlebars
@@ -20,7 +20,7 @@
         {{/if}}
         </p>
         {{#if description}}
-        <p>"{{description}}"</p>
+        <b>Description: </b><p>"{{description}}"</p>
         {{/if}}
 
       {{!-- if user is logged-in, shows the 'Save' accordion for the option to save a search result as a note --}}

--- a/views/searchResults.handlebars
+++ b/views/searchResults.handlebars
@@ -28,7 +28,7 @@
       <div class="accordion accordion-flush" id="accordionFlushExample">
         <div class="accordion-item">
           <h2 class="accordion-header" id="flush-headingOne">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+            <button class="accordion-button collapsed btn btn-secondary btn-sm" type="button" data-bs-toggle="collapse"
               data-bs-target="#flush-collapse{{id}}" aria-expanded="false" aria-controls="flush-collapseOne">
               Save
             </button>


### PR DESCRIPTION
Added link to repo next to the link for more clarity 


<img width="1792" alt="Screenshot 2023-02-16 at 4 57 28 PM" src="https://user-images.githubusercontent.com/97576504/219506832-734c0b42-4f53-40a7-a01e-fd427cdd9f51.png">
